### PR TITLE
generate.py: fix the warn_unused_result

### DIFF
--- a/src/generate.py
+++ b/src/generate.py
@@ -181,7 +181,7 @@ def generate_C_parse(obj, c_file):
                 c_file.write('    }\n')
         for i in required_to_check:
             c_file.write('    if (ret->%s == NULL) {\n' % i.origname)
-            c_file.write('        asprintf (err, "Required field %%s not present", "%s");\n' % i.origname)
+            c_file.write('        int unused = asprintf (err, "Required field %%s not present", "%s");\n' % i.origname)
             c_file.write("        free_%s (ret);\n" % obj_typename)
             c_file.write("        return NULL;\n")
             c_file.write('    }\n')


### PR DESCRIPTION
```
'asprintf', declared with attribute warn_unused_result [-Wunused-result]
         asprintf (err, "Required field %s not present", "args");
         ^
```

Signed-off-by: 0x0916 <w@laoqinren.net>