### PR TITLE
rename `sepc.{h|c}` to `oci_runtime_spec.{h/c}`

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 *.o
 *.a
-src/spec.c
-src/spec.h
+src/oci_runtime_spec.c
+src/oci_runtime_spec.h
 Makefile
 Makefile.in
 aclocal.m4
@@ -25,4 +25,3 @@ tests/.deps/
 tests/.dirstamp
 tests/test-1
 tests/test-2
-

--- a/Makefile.am
+++ b/Makefile.am
@@ -6,14 +6,14 @@ GITIGNOREFILES = build-aux/ gtk-doc.make config.h.in aclocal.m4
 
 noinst_LIBRARIES = libocispec.a
 
-libocispec_a_SOURCES = src/spec.c src/read-file.c
+libocispec_a_SOURCES = src/oci_runtime_spec.c src/read-file.c
 
-src/spec.c: runtime-spec/schema/config-schema.json src/generate.py
-	(cd src; ./generate.py ../runtime-spec/schema/config-schema.json spec.h spec.c)
+src/oci_runtime_spec.c: runtime-spec/schema/config-schema.json src/generate.py
+	(cd src; ./generate.py ../runtime-spec/schema/config-schema.json oci_runtime_spec.h oci_runtime_spec.c)
 
-src/spec.h: src/spec.c
+src/oci_runtime_spec.h: src/oci_runtime_spec.c
 
-CLEANFILES += src/spec.h src/spec.c
+CLEANFILES += src/oci_runtime_spec.h src/oci_runtime_spec.c
 
 tests_test_1_SOURCES = tests/test-1.c
 tests_test_1_CFLAGS = -I$(builddir)/src
@@ -36,7 +36,7 @@ TESTS = tests/test-1 tests/test-2
 TEST_EXTENSIONS = .conf
 CONF_LOG_COMPILER = $(top_srcdir)/tests/tests-runner
 
-EXTRA_DIST = autogen.sh src/spec.h src/read-file.h
+EXTRA_DIST = autogen.sh src/oci_runtime_spec.h src/read-file.h
 
 EXTRA_DIST += $(TESTS:.conf=.conf.expected)
 EXTRA_DIST += $(TESTS:.conf=.conf.command)

--- a/src/validate.c
+++ b/src/validate.c
@@ -21,7 +21,7 @@ along with libocispec.  If not, see <http://www.gnu.org/licenses/>.
 #include <stdlib.h>
 #include <string.h>
 #include <error.h>
-#include "spec.h"
+#include "oci_runtime_spec.h"
 
 int
 main (int argc, char *argv[])

--- a/tests/test-1.c
+++ b/tests/test-1.c
@@ -20,7 +20,7 @@ along with libocispec.  If not, see <http://www.gnu.org/licenses/>.
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "spec.h"
+#include "oci_runtime_spec.h"
 
 int
 main (int argc, char *argv[])

--- a/tests/test-2.c
+++ b/tests/test-2.c
@@ -20,7 +20,7 @@ along with libocispec.  If not, see <http://www.gnu.org/licenses/>.
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-#include "spec.h"
+#include "oci_runtime_spec.h"
 
 int
 main (int argc, char *argv[])


### PR DESCRIPTION
The `libocispec` current only support `runtime-spec`,
it maybe support other oci spec(oci_images_spec.h) in future.
also, `spec.h` is more common and prone to conflict.

Fix: https://github.com/giuseppe/libocispec/issues/7

Signed-off-by: 0x0916 <w@laoqinren.net>