### PR TITLE
generate.py: add an empty space between 'free' and '(ptr)'

### DIFF
--- a/src/generate.py
+++ b/src/generate.py
@@ -296,7 +296,7 @@ def generate_C_free(obj, c_file):
                 c_file.write("    if (ptr->%s)\n" % (i.origname))
                 c_file.write("        free_%s (ptr->%s);\n" % (typename, i.origname))
                 c_file.write("    ptr->%s = NULL;\n" % (i.origname))
-    c_file.write("    free(ptr);\n")
+    c_file.write("    free (ptr);\n")
     c_file.write("}\n\n")
 
 def append_type_C_header(obj, header):


### PR DESCRIPTION
add en empty space between `free` and `(ptr)`, so we generate
similar code.

Signed-off-by: 0x0916 <w@laoqinren.net>