### PR TITLE
libocispec: add support for oci image spec

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,8 @@ src/oci_image_spec.c
 src/oci_image_spec.h
 src/oci_image_index_spec.c
 src/oci_image_index_spec.h
+src/oci_image_layout_spec.c
+src/oci_image_layout_spec.h
 Makefile
 Makefile.in
 aclocal.m4

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,8 @@ src/oci_image_index_spec.c
 src/oci_image_index_spec.h
 src/oci_image_layout_spec.c
 src/oci_image_layout_spec.h
+src/oci_image_manifest_spec.c
+src/oci_image_manifest_spec.h
 Makefile
 Makefile.in
 aclocal.m4
@@ -34,5 +36,17 @@ tests/test-1.log
 tests/test-1.trs
 tests/test-2.log
 tests/test-2.trs
+tests/test-3.log
+tests/test-3.trs
+tests/test-4.log
+tests/test-4.trs
+tests/test-5.log
+tests/test-5.trs
+tests/test-6.log
+tests/test-6.trs
 tests/test-1
 tests/test-2
+tests/test-3
+tests/test-4
+tests/test-5
+tests/test-6

--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 *.a
 src/oci_runtime_spec.c
 src/oci_runtime_spec.h
+src/oci_image_spec.c
+src/oci_image_spec.h
+
 Makefile
 Makefile.in
 aclocal.m4

--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,8 @@ src/oci_runtime_spec.c
 src/oci_runtime_spec.h
 src/oci_image_spec.c
 src/oci_image_spec.h
-
+src/oci_image_index_spec.c
+src/oci_image_index_spec.h
 Makefile
 Makefile.in
 aclocal.m4

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,6 @@
 [submodule "runtime-spec"]
 	path = runtime-spec
 	url = https://github.com/opencontainers/runtime-spec
+[submodule "image-spec"]
+	path = image-spec
+	url = https://github.com/opencontainers/image-spec

--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,8 @@ noinst_LIBRARIES = libocispec.a
 libocispec_a_SOURCES = src/oci_runtime_spec.c src/read-file.c \
 			src/oci_image_spec.c \
 			src/oci_image_index_spec.c \
-			src/oci_image_layout_spec.c
+			src/oci_image_layout_spec.c \
+			src/oci_image_manifest_spec.c
 
 src/oci_runtime_spec.c: runtime-spec/schema/config-schema.json src/generate.py
 	(cd src; ./generate.py ../runtime-spec/schema/config-schema.json oci_runtime_spec.h oci_runtime_spec.c container)
@@ -34,10 +35,16 @@ src/oci_image_layout_spec.c: image-spec/schema/image-layout-schema.json src/gene
 
 src/oci_image_layout_spec.h: src/oci_image_layout_spec.c
 
+src/oci_image_manifest_spec.c: image-spec/schema/image-manifest-schema.json src/generate.py
+	(cd src; ./generate.py ../image-spec/schema/image-manifest-schema.json oci_image_manifest_spec.h oci_image_manifest_spec.c image_manifest)
+
+src/oci_image_manifest_spec.h: src/oci_image_manifest_spec.c
+
 CLEANFILES += src/oci_runtime_spec.h src/oci_runtime_spec.c \
 		src/oci_image_spec.h src/oci_image_spec.c \
 		src/oci_image_index_spec.h src/oci_image_index_spec.c \
-		src/oci_image_layout_spec.h src/oci_image_layout_spec.c
+		src/oci_image_layout_spec.h src/oci_image_layout_spec.c \
+		src/oci_image_manifest_spec.h src/oci_image_manifest_spec.c
 
 tests_test_1_SOURCES = tests/test-1.c
 tests_test_1_CFLAGS = -I$(builddir)/src

--- a/Makefile.am
+++ b/Makefile.am
@@ -55,14 +55,20 @@ tests_test_4_SOURCES = tests/test-4.c
 tests_test_4_CFLAGS = -I$(builddir)/src
 tests_test_4_LDADD = libocispec.a $(SELINUX_LIBS) $(YAJL_LIBS)
 
+tests_test_5_SOURCES = tests/test-5.c
+tests_test_5_CFLAGS = -I$(builddir)/src
+tests_test_5_LDADD = libocispec.a $(SELINUX_LIBS) $(YAJL_LIBS)
+
 src_validate_SOURCES = src/validate.c
 src_validate_CFLAGS = -I$(builddir)/src
 src_validate_LDADD = libocispec.a $(SELINUX_LIBS) $(YAJL_LIBS)
 
 bin_PROGRAMS = src/validate tests/test-1 tests/test-2 tests/test-3 \
-		tests/test-4
+		tests/test-4 \
+		tests/test-5
 
-TESTS = tests/test-1 tests/test-2 tests/test-3 tests/test-4
+TESTS = tests/test-1 tests/test-2 tests/test-3 tests/test-4 \
+		tests/test-5
 
 -include $(top_srcdir)/git.mk
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -7,7 +7,8 @@ GITIGNOREFILES = build-aux/ gtk-doc.make config.h.in aclocal.m4
 noinst_LIBRARIES = libocispec.a
 
 libocispec_a_SOURCES = src/oci_runtime_spec.c src/read-file.c \
-			src/oci_image_spec.c
+			src/oci_image_spec.c \
+			src/oci_image_index_spec.c
 
 src/oci_runtime_spec.c: runtime-spec/schema/config-schema.json src/generate.py
 	(cd src; ./generate.py ../runtime-spec/schema/config-schema.json oci_runtime_spec.h oci_runtime_spec.c container)
@@ -20,8 +21,15 @@ src/oci_image_spec.c: image-spec/schema/config-schema.json src/generate.py
 
 src/oci_image_spec.h: src/oci_image_spec.c
 
+
+src/oci_image_index_spec.c: image-spec/schema/image-index-schema.json src/generate.py
+	(cd src; ./generate.py ../image-spec/schema/image-index-schema.json oci_image_index_spec.h oci_image_index_spec.c image_index)
+
+src/oci_image_index_spec.h: src/oci_image_index_spec.c
+
 CLEANFILES += src/oci_runtime_spec.h src/oci_runtime_spec.c \
-		src/oci_image_spec.h src/oci_image_spec.c
+		src/oci_image_spec.h src/oci_image_spec.c \
+		src/oci_image_index_spec.h src/oci_image_index_spec.c
 
 tests_test_1_SOURCES = tests/test-1.c
 tests_test_1_CFLAGS = -I$(builddir)/src
@@ -49,7 +57,8 @@ TEST_EXTENSIONS = .conf
 CONF_LOG_COMPILER = $(top_srcdir)/tests/tests-runner
 
 EXTRA_DIST = autogen.sh src/oci_runtime_spec.h src/read-file.h \
-		src/oci_image_spec.h
+		src/oci_image_spec.h \
+		src/oci_image_index_spec.h
 
 EXTRA_DIST += $(TESTS:.conf=.conf.expected)
 EXTRA_DIST += $(TESTS:.conf=.conf.command)

--- a/Makefile.am
+++ b/Makefile.am
@@ -6,14 +6,22 @@ GITIGNOREFILES = build-aux/ gtk-doc.make config.h.in aclocal.m4
 
 noinst_LIBRARIES = libocispec.a
 
-libocispec_a_SOURCES = src/oci_runtime_spec.c src/read-file.c
+libocispec_a_SOURCES = src/oci_runtime_spec.c src/read-file.c \
+			src/oci_image_spec.c
 
 src/oci_runtime_spec.c: runtime-spec/schema/config-schema.json src/generate.py
 	(cd src; ./generate.py ../runtime-spec/schema/config-schema.json oci_runtime_spec.h oci_runtime_spec.c container)
 
 src/oci_runtime_spec.h: src/oci_runtime_spec.c
 
-CLEANFILES += src/oci_runtime_spec.h src/oci_runtime_spec.c
+
+src/oci_image_spec.c: image-spec/schema/config-schema.json src/generate.py
+	(cd src; ./generate.py ../image-spec/schema/config-schema.json oci_image_spec.h oci_image_spec.c image)
+
+src/oci_image_spec.h: src/oci_image_spec.c
+
+CLEANFILES += src/oci_runtime_spec.h src/oci_runtime_spec.c \
+		src/oci_image_spec.h src/oci_image_spec.c
 
 tests_test_1_SOURCES = tests/test-1.c
 tests_test_1_CFLAGS = -I$(builddir)/src
@@ -36,7 +44,8 @@ TESTS = tests/test-1 tests/test-2
 TEST_EXTENSIONS = .conf
 CONF_LOG_COMPILER = $(top_srcdir)/tests/tests-runner
 
-EXTRA_DIST = autogen.sh src/oci_runtime_spec.h src/read-file.h
+EXTRA_DIST = autogen.sh src/oci_runtime_spec.h src/read-file.h \
+		src/oci_image_spec.h
 
 EXTRA_DIST += $(TESTS:.conf=.conf.expected)
 EXTRA_DIST += $(TESTS:.conf=.conf.command)

--- a/Makefile.am
+++ b/Makefile.am
@@ -43,13 +43,18 @@ tests_test_3_SOURCES = tests/test-3.c
 tests_test_3_CFLAGS = -I$(builddir)/src
 tests_test_3_LDADD = libocispec.a $(SELINUX_LIBS) $(YAJL_LIBS)
 
+tests_test_4_SOURCES = tests/test-4.c
+tests_test_4_CFLAGS = -I$(builddir)/src
+tests_test_4_LDADD = libocispec.a $(SELINUX_LIBS) $(YAJL_LIBS)
+
 src_validate_SOURCES = src/validate.c
 src_validate_CFLAGS = -I$(builddir)/src
 src_validate_LDADD = libocispec.a $(SELINUX_LIBS) $(YAJL_LIBS)
 
-bin_PROGRAMS = src/validate tests/test-1 tests/test-2 tests/test-3
+bin_PROGRAMS = src/validate tests/test-1 tests/test-2 tests/test-3 \
+		tests/test-4
 
-TESTS = tests/test-1 tests/test-2 tests/test-3
+TESTS = tests/test-1 tests/test-2 tests/test-3 tests/test-4
 
 -include $(top_srcdir)/git.mk
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -9,7 +9,7 @@ noinst_LIBRARIES = libocispec.a
 libocispec_a_SOURCES = src/oci_runtime_spec.c src/read-file.c
 
 src/oci_runtime_spec.c: runtime-spec/schema/config-schema.json src/generate.py
-	(cd src; ./generate.py ../runtime-spec/schema/config-schema.json oci_runtime_spec.h oci_runtime_spec.c)
+	(cd src; ./generate.py ../runtime-spec/schema/config-schema.json oci_runtime_spec.h oci_runtime_spec.c container)
 
 src/oci_runtime_spec.h: src/oci_runtime_spec.c
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -8,7 +8,8 @@ noinst_LIBRARIES = libocispec.a
 
 libocispec_a_SOURCES = src/oci_runtime_spec.c src/read-file.c \
 			src/oci_image_spec.c \
-			src/oci_image_index_spec.c
+			src/oci_image_index_spec.c \
+			src/oci_image_layout_spec.c
 
 src/oci_runtime_spec.c: runtime-spec/schema/config-schema.json src/generate.py
 	(cd src; ./generate.py ../runtime-spec/schema/config-schema.json oci_runtime_spec.h oci_runtime_spec.c container)
@@ -27,9 +28,16 @@ src/oci_image_index_spec.c: image-spec/schema/image-index-schema.json src/genera
 
 src/oci_image_index_spec.h: src/oci_image_index_spec.c
 
+
+src/oci_image_layout_spec.c: image-spec/schema/image-layout-schema.json src/generate.py
+	(cd src; ./generate.py ../image-spec/schema/image-layout-schema.json oci_image_layout_spec.h oci_image_layout_spec.c image_layout)
+
+src/oci_image_layout_spec.h: src/oci_image_layout_spec.c
+
 CLEANFILES += src/oci_runtime_spec.h src/oci_runtime_spec.c \
 		src/oci_image_spec.h src/oci_image_spec.c \
-		src/oci_image_index_spec.h src/oci_image_index_spec.c
+		src/oci_image_index_spec.h src/oci_image_index_spec.c \
+		src/oci_image_layout_spec.h src/oci_image_layout_spec.c
 
 tests_test_1_SOURCES = tests/test-1.c
 tests_test_1_CFLAGS = -I$(builddir)/src

--- a/Makefile.am
+++ b/Makefile.am
@@ -66,16 +66,22 @@ tests_test_5_SOURCES = tests/test-5.c
 tests_test_5_CFLAGS = -I$(builddir)/src
 tests_test_5_LDADD = libocispec.a $(SELINUX_LIBS) $(YAJL_LIBS)
 
+tests_test_6_SOURCES = tests/test-6.c
+tests_test_6_CFLAGS = -I$(builddir)/src
+tests_test_6_LDADD = libocispec.a $(SELINUX_LIBS) $(YAJL_LIBS)
+
 src_validate_SOURCES = src/validate.c
 src_validate_CFLAGS = -I$(builddir)/src
 src_validate_LDADD = libocispec.a $(SELINUX_LIBS) $(YAJL_LIBS)
 
 bin_PROGRAMS = src/validate tests/test-1 tests/test-2 tests/test-3 \
 		tests/test-4 \
-		tests/test-5
+		tests/test-5 \
+		tests/test-6
 
 TESTS = tests/test-1 tests/test-2 tests/test-3 tests/test-4 \
-		tests/test-5
+		tests/test-5	\
+		tests/test-6
 
 -include $(top_srcdir)/git.mk
 

--- a/Makefile.am
+++ b/Makefile.am
@@ -31,13 +31,17 @@ tests_test_2_SOURCES = tests/test-2.c
 tests_test_2_CFLAGS = -I$(builddir)/src
 tests_test_2_LDADD = libocispec.a $(SELINUX_LIBS) $(YAJL_LIBS)
 
+tests_test_3_SOURCES = tests/test-3.c
+tests_test_3_CFLAGS = -I$(builddir)/src
+tests_test_3_LDADD = libocispec.a $(SELINUX_LIBS) $(YAJL_LIBS)
+
 src_validate_SOURCES = src/validate.c
 src_validate_CFLAGS = -I$(builddir)/src
 src_validate_LDADD = libocispec.a $(SELINUX_LIBS) $(YAJL_LIBS)
 
-bin_PROGRAMS = src/validate tests/test-1 tests/test-2
+bin_PROGRAMS = src/validate tests/test-1 tests/test-2 tests/test-3
 
-TESTS = tests/test-1 tests/test-2
+TESTS = tests/test-1 tests/test-2 tests/test-3
 
 -include $(top_srcdir)/git.mk
 

--- a/src/generate.py
+++ b/src/generate.py
@@ -37,7 +37,10 @@ class Name:
 class Node:
     def __init__(self, name, typ, children, subtyp=None, subtypobj=None, required=None):
         self.name = name.name
-        self.origname = name.leaf or name.name
+        if (name.leaf):
+            self.origname = name.leaf.replace('.', '_')
+        else:
+            self.origname = name.name.replace('.', '_')
         self.typ = typ
         self.children = children
         self.subtyp = subtyp

--- a/src/generate.py
+++ b/src/generate.py
@@ -354,22 +354,27 @@ def append_type_C_header(obj, header, prefix):
         header.write("%s *make_%s (yajl_val tree, struct libocispec_context *ctx, oci_parser_error *err);\n\n" % (typename, typename))
 
 def get_ref(src, ref):
-    f, r = ref.split("#/")
+    if '#/' in ref:
+        f, r = ref.split("#/")
+    else:
+        f = ref
+        r = ""
+
     if f == "":
         cur = src
     else:
         with open(f) as i:
             cur = src = json.loads(i.read())
-
-    for j in r.split('/'):
-        basic_types = [
-            "int8", "int16", "int32", "int64",
-            "uint8", "uint16", "uint32", "uint64", "UID", "GID",
-            "mapStringString", "ArrayOfStrings"
-        ]
-        if j in basic_types:
-            return src, {"type" : j}
-        cur = cur[j]
+    if r != "":
+        for j in r.split('/'):
+            basic_types = [
+                "int8", "int16", "int32", "int64",
+                "uint8", "uint16", "uint32", "uint64", "UID", "GID",
+                "mapStringString", "ArrayOfStrings"
+            ]
+            if j in basic_types:
+                return src, {"type" : j}
+            cur = cur[j]
 
     if 'type' not in cur and '$ref' in cur:
         return get_ref(src, cur['$ref'])

--- a/src/generate.py
+++ b/src/generate.py
@@ -387,6 +387,12 @@ def resolve_type(name, src, cur):
     if 'patternProperties' in cur:
         # if a patternProperties, take the first value
         typ = cur['patternProperties'].values()[0]["type"]
+    elif "oneOf" in cur:
+        cur = cur['oneOf'][0]
+        if '$ref' in cur:
+            return resolve_type(name, src, cur)
+        else:
+            typ = cur['type']
     elif "type" in cur:
         typ = cur["type"]
     else:

--- a/src/validate.c
+++ b/src/validate.c
@@ -37,7 +37,7 @@ main (int argc, char *argv[])
   ctx.options = LIBOCISPEC_OPTIONS_STRICT;
   ctx.stderr = stderr;
 
-  container = oci_parse_file (file, &ctx, &err);
+  container = oci_container_parse_file (file, &ctx, &err);
   if (container)
     free_oci_container_container (container);
 

--- a/tests/image_config.json
+++ b/tests/image_config.json
@@ -1,0 +1,53 @@
+{
+    "created": "2015-10-31T22:22:56.015925234Z",
+    "author": "Alyssa P. Hacker <alyspdev@example.com>",
+    "architecture": "amd64",
+    "os": "linux",
+    "config": {
+        "User": "1:1",
+        "ExposedPorts": {
+            "8080/tcp": {}
+        },
+        "Env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "FOO=docker_is_a_really",
+            "BAR=great_tool_you_know"
+        ],
+        "Entrypoint": [
+            "/bin/sh"
+        ],
+        "Cmd": [
+            "--foreground",
+            "--config",
+            "/etc/my-app.d/default.cfg"
+        ],
+        "Volumes": {
+            "/var/job-result-data": {},
+            "/var/log/my-app-logs": {}
+        },
+        "StopSignal": "SIGKILL",
+        "WorkingDir": "/home/alice",
+        "Labels": {
+            "com.example.project.git.url": "https://example.com/project.git",
+            "com.example.project.git.commit": "45a939b2999782a3f005621a8d0f29aa387e1d6b"
+        }
+    },
+    "rootfs": {
+      "diff_ids": [
+        "sha256:9d3dd9504c685a304985025df4ed0283e47ac9ffa9bd0326fddf4d59513f0827",
+        "sha256:2b689805fbd00b2db1df73fae47562faac1a626d5f61744bfe29946ecff5d73d"
+      ],
+      "type": "layers"
+    },
+    "history": [
+      {
+        "created": "2015-10-31T22:22:54.690851953Z",
+        "created_by": "/bin/sh -c #(nop) ADD file:a3bc1e842b69636f9df5256c49c5374fb4eef1e281fe3f282c65fb853ee171c5 in /"
+      },
+      {
+        "created": "2015-10-31T22:22:55.613815829Z",
+        "created_by": "/bin/sh -c #(nop) CMD [\"sh\"]",
+        "empty_layer": true
+      }
+    ]
+}

--- a/tests/image_index_config.json
+++ b/tests/image_index_config.json
@@ -1,0 +1,27 @@
+{
+  "schemaVersion": 2,
+  "manifests": [
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "size": 7143,
+      "digest": "sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f",
+      "platform": {
+        "architecture": "ppc64le",
+        "os": "linux"
+      }
+    },
+    {
+      "mediaType": "application/vnd.oci.image.manifest.v1+json",
+      "size": 7682,
+      "digest": "sha256:5b0bcabd1ed22e9fb1310cf6c2dec7cdef19f0ad69efa1f392e94a4333501270",
+      "platform": {
+        "architecture": "amd64",
+        "os": "linux"
+      }
+    }
+  ],
+  "annotations": {
+    "com.example.key1": "value1",
+    "com.example.key2": "value2"
+  }
+}

--- a/tests/image_layout_config.json
+++ b/tests/image_layout_config.json
@@ -1,0 +1,3 @@
+{
+  "imageLayoutVersion": "1.0.0"
+}

--- a/tests/image_manifest.json
+++ b/tests/image_manifest.json
@@ -1,0 +1,29 @@
+{
+	"schemaVersion": 2,
+	"config": {
+		"mediaType": "application/vnd.oci.image.config.v1+json",
+		"size": 1470,
+		"digest": "sha256:c86f7763873b6c0aae22d963bab59b4f5debbed6685761b5951584f6efb0633b"
+	},
+	"layers": [
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"size": 675598,
+			"digest": "sha256:9d3dd9504c685a304985025df4ed0283e47ac9ffa9bd0326fddf4d59513f0827"
+		},
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"size": 156,
+			"digest": "sha256:2b689805fbd00b2db1df73fae47562faac1a626d5f61744bfe29946ecff5d73d"
+		},
+		{
+			"mediaType": "application/vnd.oci.image.layer.v1.tar+gzip",
+			"size": 148,
+			"digest": "sha256:c57089565e894899735d458f0fd4bb17a0f1e0df8d72da392b85c9b35ee777cd"
+		}
+	],
+	"annotations": {
+		"key1": "value1",
+		"key2": "value2"
+	}
+}

--- a/tests/test-1.c
+++ b/tests/test-1.c
@@ -26,7 +26,7 @@ int
 main (int argc, char *argv[])
 {
   oci_parser_error err;
-  oci_container_container *container = oci_parse_file ("tests/config.json", 0, &err);
+  oci_container_container *container = oci_container_parse_file ("tests/config.json", 0, &err);
 
   if (container == NULL) {
     printf ("error %s\n", err);

--- a/tests/test-2.c
+++ b/tests/test-2.c
@@ -26,7 +26,7 @@ int
 main (int argc, char *argv[])
 {
   oci_parser_error err;
-  oci_container_container *container = oci_parse_file ("tests/config.nocwd.json", 0, &err);
+  oci_container_container *container = oci_container_parse_file ("tests/config.nocwd.json", 0, &err);
   if (container != NULL) {
     exit (4);
   }

--- a/tests/test-3.c
+++ b/tests/test-3.c
@@ -1,0 +1,51 @@
+/* Copyright (C) 2017 Wang Long <w@laoqinren.net>
+
+libocispec is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+libocispec is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libocispec.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+#include "config.h"
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "oci_image_spec.h"
+
+int
+main (int argc, char *argv[])
+{
+  oci_parser_error err;
+  oci_image_image *image = oci_image_parse_file ("tests/image_config.json", 0, &err);
+
+  if (image == NULL) {
+    printf ("error %s\n", err);
+    exit (1);
+  }
+  if (strcmp (image->author, "Alyssa P. Hacker <alyspdev@example.com>"))
+    exit (5);
+  if (strcmp (image->created, "2015-10-31T22:22:56.015925234Z"))
+    exit (5);
+  if (strcmp (image->os, "linux"))
+    exit (5);
+  if (strcmp (image->architecture, "amd64"))
+    exit (5);
+  if (strcmp (image->config->User, "1:1"))
+    exit (5);
+  if (strcmp (image->config->Env[1], "FOO=docker_is_a_really"))
+    exit (5);
+  if (strcmp (image->config->Entrypoint[0], "/bin/sh"))
+    exit (5);
+  free_oci_image_image (image);
+  exit (0);
+}

--- a/tests/test-4.c
+++ b/tests/test-4.c
@@ -1,0 +1,58 @@
+/* Copyright (C) 2017 Wang Long <w@laoqinren.net>
+
+libocispec is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+libocispec is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libocispec.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+#include "config.h"
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "oci_image_index_spec.h"
+
+int
+main (int argc, char *argv[])
+{
+  oci_parser_error err;
+  oci_image_index_image_index *image_index = oci_image_index_parse_file ("tests/image_index_config.json", 0, &err);
+
+  if (image_index == NULL) {
+    printf ("error %s\n", err);
+    exit (1);
+  }
+  if (image_index->schemaVersion != 2)
+    exit (5);
+  if (image_index->annotations->len != 2)
+    exit (5);
+  if (image_index->annotations->len != 2)
+    exit (5);
+  if (strcmp (image_index->annotations->keys[0], "com.example.key1"))
+    exit (5);
+  if (strcmp (image_index->annotations->values[1], "value2"))
+    exit (5);
+  if (strcmp (image_index->manifests[0]->mediaType, "application/vnd.oci.image.manifest.v1+json"))
+    exit (5);
+  if (image_index->manifests[0]->size != 7143)
+    exit (5);
+  if (strcmp (image_index->manifests[0]->digest, "sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f"))
+    exit (5);
+  if (strcmp (image_index->manifests[0]->platform->os, "linux"))
+    exit (5);
+  if (strcmp (image_index->manifests[0]->platform->architecture, "ppc64le"))
+    exit (5);
+
+  free_oci_image_index_image_index (image_index);
+  exit (0);
+}

--- a/tests/test-5.c
+++ b/tests/test-5.c
@@ -1,0 +1,40 @@
+/* Copyright (C) 2017 Wang Long <w@laoqinren.net>
+
+libocispec is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+libocispec is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libocispec.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+#include "config.h"
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "oci_image_layout_spec.h"
+
+int
+main (int argc, char *argv[])
+{
+  oci_parser_error err;
+  oci_image_layout_image_layout *image_layout = oci_image_layout_parse_file ("tests/image_layout_config.json", 0, &err);
+
+  if (image_layout == NULL) {
+    printf ("error %s\n", err);
+    exit (1);
+  }
+  if (strcmp (image_layout->imageLayoutVersion, "1.0.0"))
+    exit (5);
+
+  free_oci_image_layout_image_layout (image_layout);
+  exit (0);
+}

--- a/tests/test-6.c
+++ b/tests/test-6.c
@@ -1,0 +1,53 @@
+/* Copyright (C) 2017 Yifeng Tan <tanyifeng1@huawei.com>
+
+libocispec is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+libocispec is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libocispec.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+#include "config.h"
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "oci_image_manifest_spec.h"
+
+int
+main (int argc, char *argv[])
+{
+  oci_parser_error err;
+  oci_image_manifest_image_manifest *manifest = oci_image_manifest_parse_file ("tests/image_manifest.json", 0, &err);
+
+  if (manifest == NULL) {
+    printf ("error %s\n", err);
+    exit (1);
+  }
+  if (manifest->schemaVersion != 2)
+    exit (5);
+  if (strcmp (manifest->config->mediaType, "application/vnd.oci.image.config.v1+json"))
+    exit (5);
+  if (manifest->config->size != 1470)
+    exit (5);
+  if (manifest->layers_len != 3)
+    exit (5);
+  if (strcmp (manifest->layers[1]->digest, "sha256:2b689805fbd00b2db1df73fae47562faac1a626d5f61744bfe29946ecff5d73d"))
+    exit (5);
+  if (manifest->annotations->len != 2)
+    exit (5);
+  if (strcmp(manifest->annotations->keys[1], "key2"))
+    exit (5);
+  if (strcmp(manifest->annotations->values[1], "value2"))
+    exit (5);
+  free_oci_image_manifest_image_manifest (manifest);
+  exit (0);
+}


### PR DESCRIPTION
@giuseppe This pr first make `generate.py` more generic and then add support for oci image spec, including image_spec, image_index_spec, image_layout_spec, image_manifest_spec.

Also we add test case for image spec.