### PR TITLE
fix generate_C_parse if a key has '.', modify tests

### DIFF
--- a/tests/image_index_config.json
+++ b/tests/image_index_config.json
@@ -7,7 +7,12 @@
       "digest": "sha256:e692418e4cbaf90ca69d05a66403747baa33ee08806650b51fab815ad7fc331f",
       "platform": {
         "architecture": "ppc64le",
-        "os": "linux"
+        "os": "linux",
+	"os.version": "1.0.0",
+	"os.features": [
+		"fast",
+		"simple"
+	]
       }
     },
     {

--- a/tests/test-4.c
+++ b/tests/test-4.c
@@ -50,6 +50,12 @@ main (int argc, char *argv[])
     exit (5);
   if (strcmp (image_index->manifests[0]->platform->os, "linux"))
     exit (5);
+  if (strcmp (image_index->manifests[0]->platform->os_version, "1.0.0"))
+    exit (5);
+  if (image_index->manifests[0]->platform->os_features_len != 2)
+    exit (5);
+  if (strcmp (image_index->manifests[0]->platform->os_features[1], "simple"))
+    exit (5);
   if (strcmp (image_index->manifests[0]->platform->architecture, "ppc64le"))
     exit (5);
 


### PR DESCRIPTION
This PR can resolve such json-schema:
```
"os.version": {
    "type": string
}
```
which is found in [image-spec/schema/image-index-schema.json](https://github.com/opencontainers/image-spec/blob/master/schema/image-index-schema.json)

and the original corresponding .c file is:
```
if (get_val (tree, "os_version", yajl_t_string))
            ret->os_version = strdup (YAJL_GET_STRING (get_val (tree, "os_version", yajl_t_string)) ? : "");
```
generated error key "os_version" in get_val().

Now, it become the correct one:
```
if (get_val (tree, "os.version", yajl_t_string))
            ret->os_version = strdup (YAJL_GET_STRING (get_val (tree, "os.version", yajl_t_string)) ? : "");

Signed-off-by: Yifeng Tan <tanyifeng1@huawei.com>
```
We also modify some test for the changes.