### PR TITLE
add support for type mapStringObject

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,9 +44,12 @@ tests/test-5.log
 tests/test-5.trs
 tests/test-6.log
 tests/test-6.trs
+tests/test-7.log
+tests/test-7.trs
 tests/test-1
 tests/test-2
 tests/test-3
 tests/test-4
 tests/test-5
 tests/test-6
+tests/test-7

--- a/Makefile.am
+++ b/Makefile.am
@@ -70,6 +70,10 @@ tests_test_6_SOURCES = tests/test-6.c
 tests_test_6_CFLAGS = -I$(builddir)/src
 tests_test_6_LDADD = libocispec.a $(SELINUX_LIBS) $(YAJL_LIBS)
 
+tests_test_7_SOURCES = tests/test-7.c
+tests_test_7_CFLAGS = -I$(builddir)/src
+tests_test_7_LDADD = libocispec.a $(SELINUX_LIBS) $(YAJL_LIBS)
+
 src_validate_SOURCES = src/validate.c
 src_validate_CFLAGS = -I$(builddir)/src
 src_validate_LDADD = libocispec.a $(SELINUX_LIBS) $(YAJL_LIBS)
@@ -77,11 +81,13 @@ src_validate_LDADD = libocispec.a $(SELINUX_LIBS) $(YAJL_LIBS)
 bin_PROGRAMS = src/validate tests/test-1 tests/test-2 tests/test-3 \
 		tests/test-4 \
 		tests/test-5 \
-		tests/test-6
+		tests/test-6 \
+		tests/test-7
 
 TESTS = tests/test-1 tests/test-2 tests/test-3 tests/test-4 \
 		tests/test-5	\
-		tests/test-6
+		tests/test-6	\
+		tests/test-7
 
 -include $(top_srcdir)/git.mk
 

--- a/tests/image_config_mapstringobject.json
+++ b/tests/image_config_mapstringobject.json
@@ -1,0 +1,47 @@
+{
+    "created": "2015-10-31T22:22:56.015925234Z",
+    "author": "Alyssa P. Hacker <alyspdev@example.com>",
+    "architecture": "amd64",
+    "os": "linux",
+    "config": {
+        "User": "1:1",
+        "Env": [
+            "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
+            "FOO=docker_is_a_really",
+            "BAR=great_tool_you_know"
+        ],
+        "Entrypoint": [
+            "/bin/sh"
+        ],
+        "Cmd": [
+            "--foreground",
+            "--config",
+            "/etc/my-app.d/default.cfg"
+        ],
+        "Volumes": null,
+        "StopSignal": "SIGKILL",
+        "WorkingDir": "/home/alice",
+        "Labels": {
+            "com.example.project.git.url": "https://example.com/project.git",
+            "com.example.project.git.commit": "45a939b2999782a3f005621a8d0f29aa387e1d6b"
+        }
+    },
+    "rootfs": {
+      "diff_ids": [
+        "sha256:9d3dd9504c685a304985025df4ed0283e47ac9ffa9bd0326fddf4d59513f0827",
+        "sha256:2b689805fbd00b2db1df73fae47562faac1a626d5f61744bfe29946ecff5d73d"
+      ],
+      "type": "layers"
+    },
+    "history": [
+      {
+        "created": "2015-10-31T22:22:54.690851953Z",
+        "created_by": "/bin/sh -c #(nop) ADD file:a3bc1e842b69636f9df5256c49c5374fb4eef1e281fe3f282c65fb853ee171c5 in /"
+      },
+      {
+        "created": "2015-10-31T22:22:55.613815829Z",
+        "created_by": "/bin/sh -c #(nop) CMD [\"sh\"]",
+        "empty_layer": true
+      }
+    ]
+}

--- a/tests/test-3.c
+++ b/tests/test-3.c
@@ -46,6 +46,12 @@ main (int argc, char *argv[])
     exit (5);
   if (strcmp (image->config->Entrypoint[0], "/bin/sh"))
     exit (5);
+  if (image->config->Volumes_len != 2)
+    exit (5);
+  if (strcmp (image->config->Volumes[0], "/var/job-result-data"))
+    exit (5);
+  if (strcmp (image->config->Volumes[1], "/var/log/my-app-logs"))
+    exit (5);
   free_oci_image_image (image);
   exit (0);
 }

--- a/tests/test-7.c
+++ b/tests/test-7.c
@@ -1,0 +1,45 @@
+/* Copyright (C) 2017 Wang Long <w@laoqinren.net>
+
+libocispec is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+libocispec is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libocispec.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+#include "config.h"
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "oci_image_spec.h"
+
+int
+main (int argc, char *argv[])
+{
+  oci_parser_error err;
+  oci_image_image *image = oci_image_parse_file ("tests/image_config_mapstringobject.json", 0, &err);
+
+  if (image == NULL) {
+    printf ("error %s\n", err);
+    exit (1);
+  }
+  if (image->config->Volumes_len != 0)
+    exit (5);
+  if (image->config->Volumes != NULL)
+    exit (5);
+  if (image->config->ExposedPorts_len != 0)
+    exit (5);
+  if (image->config->ExposedPorts != NULL)
+    exit (5);
+  free_oci_image_image (image);
+  exit (0);
+}


### PR DESCRIPTION
in oci image spec, the definition for `mapStringObject` is

```
"mapStringObject": {
   "type": "object",
   "patternProperties": {
       ".{1,}": {
          "type": "object"
       }
   }
}
```
and in the example config, the json config file as following:

```
{
    "Volumes": null,
}

```

Or

```
{
   "Volumes": {
        "/var/lib/docker": {}
   }
}
```

So we generate c code for `mapStringObject` as same as array of strings.
the array value comes from the key.