### PR TITLE
transform all the generated name to Linux Kernel Naming

### DIFF
--- a/tests/test-1.c
+++ b/tests/test-1.c
@@ -42,25 +42,25 @@ main (int argc, char *argv[])
     exit (5);
   if (strcmp (container->mounts[0]->destination, "/proc"))
     exit (5);
-  if (container->linux->resources->blockIO->weightDevice[0]->major != 8)
+  if (container->linux->resources->block_io->weight_device[0]->major != 8)
     exit (5);
-  if (container->linux->resources->blockIO->weightDevice[0]->minor != 0)
+  if (container->linux->resources->block_io->weight_device[0]->minor != 0)
     exit (5);
-  if (container->linux->resources->blockIO->weightDevice[0]->weight != 500)
+  if (container->linux->resources->block_io->weight_device[0]->weight != 500)
     exit (5);
-  if (container->linux->resources->blockIO->weightDevice[0]->leafWeight != 300)
+  if (container->linux->resources->block_io->weight_device[0]->leaf_weight != 300)
     exit (5);
-  if (container->linux->resources->blockIO->throttleReadBpsDevice[0]->major != 8)
+  if (container->linux->resources->block_io->throttle_read_bps_device[0]->major != 8)
     exit (5);
-  if (container->linux->resources->blockIO->throttleReadBpsDevice[0]->minor != 0)
+  if (container->linux->resources->block_io->throttle_read_bps_device[0]->minor != 0)
     exit (5);
-  if (container->linux->resources->blockIO->throttleReadBpsDevice[0]->rate != 600)
+  if (container->linux->resources->block_io->throttle_read_bps_device[0]->rate != 600)
     exit (5);
-  if (container->linux->resources->blockIO->throttleWriteIopsDevice[0]->major != 8)
+  if (container->linux->resources->block_io->throttle_write_iops_device[0]->major != 8)
     exit (5);
-  if (container->linux->resources->blockIO->throttleWriteIopsDevice[0]->minor != 16)
+  if (container->linux->resources->block_io->throttle_write_iops_device[0]->minor != 16)
     exit (5);
-  if (container->linux->resources->blockIO->throttleWriteIopsDevice[0]->rate != 300)
+  if (container->linux->resources->block_io->throttle_write_iops_device[0]->rate != 300)
     exit (5);
   free_oci_container_container (container);
   exit (0);

--- a/tests/test-3.c
+++ b/tests/test-3.c
@@ -40,17 +40,17 @@ main (int argc, char *argv[])
     exit (5);
   if (strcmp (image->architecture, "amd64"))
     exit (5);
-  if (strcmp (image->config->User, "1:1"))
+  if (strcmp (image->config->user, "1:1"))
     exit (5);
-  if (strcmp (image->config->Env[1], "FOO=docker_is_a_really"))
+  if (strcmp (image->config->env[1], "FOO=docker_is_a_really"))
     exit (5);
-  if (strcmp (image->config->Entrypoint[0], "/bin/sh"))
+  if (strcmp (image->config->entrypoint[0], "/bin/sh"))
     exit (5);
-  if (image->config->Volumes_len != 2)
+  if (image->config->volumes_len != 2)
     exit (5);
-  if (strcmp (image->config->Volumes[0], "/var/job-result-data"))
+  if (strcmp (image->config->volumes[0], "/var/job-result-data"))
     exit (5);
-  if (strcmp (image->config->Volumes[1], "/var/log/my-app-logs"))
+  if (strcmp (image->config->volumes[1], "/var/log/my-app-logs"))
     exit (5);
   free_oci_image_image (image);
   exit (0);

--- a/tests/test-4.c
+++ b/tests/test-4.c
@@ -32,7 +32,7 @@ main (int argc, char *argv[])
     printf ("error %s\n", err);
     exit (1);
   }
-  if (image_index->schemaVersion != 2)
+  if (image_index->schema_version != 2)
     exit (5);
   if (image_index->annotations->len != 2)
     exit (5);
@@ -42,7 +42,7 @@ main (int argc, char *argv[])
     exit (5);
   if (strcmp (image_index->annotations->values[1], "value2"))
     exit (5);
-  if (strcmp (image_index->manifests[0]->mediaType, "application/vnd.oci.image.manifest.v1+json"))
+  if (strcmp (image_index->manifests[0]->media_type, "application/vnd.oci.image.manifest.v1+json"))
     exit (5);
   if (image_index->manifests[0]->size != 7143)
     exit (5);

--- a/tests/test-5.c
+++ b/tests/test-5.c
@@ -32,7 +32,7 @@ main (int argc, char *argv[])
     printf ("error %s\n", err);
     exit (1);
   }
-  if (strcmp (image_layout->imageLayoutVersion, "1.0.0"))
+  if (strcmp (image_layout->image_layout_version, "1.0.0"))
     exit (5);
 
   free_oci_image_layout_image_layout (image_layout);

--- a/tests/test-6.c
+++ b/tests/test-6.c
@@ -32,9 +32,9 @@ main (int argc, char *argv[])
     printf ("error %s\n", err);
     exit (1);
   }
-  if (manifest->schemaVersion != 2)
+  if (manifest->schema_version != 2)
     exit (5);
-  if (strcmp (manifest->config->mediaType, "application/vnd.oci.image.config.v1+json"))
+  if (strcmp (manifest->config->media_type, "application/vnd.oci.image.config.v1+json"))
     exit (5);
   if (manifest->config->size != 1470)
     exit (5);

--- a/tests/test-7.c
+++ b/tests/test-7.c
@@ -32,13 +32,13 @@ main (int argc, char *argv[])
     printf ("error %s\n", err);
     exit (1);
   }
-  if (image->config->Volumes_len != 0)
+  if (image->config->volumes_len != 0)
     exit (5);
-  if (image->config->Volumes != NULL)
+  if (image->config->volumes != NULL)
     exit (5);
-  if (image->config->ExposedPorts_len != 0)
+  if (image->config->exposed_ports_len != 0)
     exit (5);
-  if (image->config->ExposedPorts != NULL)
+  if (image->config->exposed_ports != NULL)
     exit (5);
   free_oci_image_image (image);
   exit (0);


### PR DESCRIPTION
We think current naming of variable or function is completely generated according to json-schema, which may not conform to linux kernel naming specification. 

So we add a function "transform_to_C_name" to translate all the uppercase to lowercase, and add '_' between adjacent word if needed.

Signed-off-by: Yifeng Tan <tanyifeng1@huawei.com>