### PR TITLE
generate simplified name of top struct

### DIFF
--- a/src/generate.py
+++ b/src/generate.py
@@ -70,6 +70,8 @@ def make_name_array(name, prefix):
     return "oci_%s_%s_element" % (prefix, name)
 
 def make_name(name, prefix):
+    if prefix == name:
+        return "oci_%s" % name
     return "oci_%s_%s" % (prefix, name)
 
 def make_pointer(name, typ, prefix):
@@ -525,9 +527,9 @@ def generate_C_header(structs, header, prefix):
     header.write("struct libocispec_context {\n    int options;\n    FILE *stderr;\n};\n\n")
     for i in structs:
         append_type_C_header(i, header, prefix)
-    header.write("oci_%s_%s *oci_%s_parse_file (const char *filename, struct libocispec_context *ctx, oci_parser_error *err);\n\n" % (prefix, prefix, prefix))
-    header.write("oci_%s_%s *oci_%s_parse_file_stream (FILE *stream, struct libocispec_context *ctx, oci_parser_error *err);\n\n" % (prefix, prefix, prefix))
-    header.write("oci_%s_%s *oci_%s_parse_data (const char *jsondata, struct libocispec_context *ctx, oci_parser_error *err);\n\n" % (prefix, prefix, prefix))
+    header.write("oci_%s *oci_%s_parse_file (const char *filename, struct libocispec_context *ctx, oci_parser_error *err);\n\n" % (prefix, prefix))
+    header.write("oci_%s *oci_%s_parse_file_stream (FILE *stream, struct libocispec_context *ctx, oci_parser_error *err);\n\n" % (prefix, prefix))
+    header.write("oci_%s *oci_%s_parse_data (const char *jsondata, struct libocispec_context *ctx, oci_parser_error *err);\n\n" % (prefix, prefix))
     header.write("#endif\n")
 
 def generate_C_code(structs, header_name, c_file, prefix):
@@ -587,7 +589,7 @@ def generate_C_code(structs, header_name, c_file, prefix):
 
 def generate_C_epilogue(c_file, prefix):
     c_file.write("""\n
-oci_%s_%s *oci_%s_parse_file (const char *filename, struct libocispec_context *ctx, oci_parser_error *err) {
+oci_%s *oci_%s_parse_file (const char *filename, struct libocispec_context *ctx, oci_parser_error *err) {
     yajl_val tree;
     size_t filesize;
     *err = NULL;
@@ -609,14 +611,14 @@ oci_%s_%s *oci_%s_parse_file (const char *filename, struct libocispec_context *c
         return NULL;
     }
 
-    oci_%s_%s *%s = make_oci_%s_%s (tree, ctx, err);
+    oci_%s *%s = make_oci_%s (tree, ctx, err);
     yajl_tree_free (tree);
     return %s;
 }
-""" % (prefix, prefix, prefix, prefix, prefix, prefix, prefix, prefix, prefix))
+""" % (prefix, prefix, prefix, prefix, prefix, prefix))
 
     c_file.write("""\n
-oci_%s_%s *oci_%s_parse_file_stream (FILE *stream, struct libocispec_context *ctx, oci_parser_error *err) {
+oci_%s *oci_%s_parse_file_stream (FILE *stream, struct libocispec_context *ctx, oci_parser_error *err) {
     yajl_val tree;
     size_t filesize;
     *err = NULL;
@@ -638,14 +640,14 @@ oci_%s_%s *oci_%s_parse_file_stream (FILE *stream, struct libocispec_context *ct
         return NULL;
     }
 
-    oci_%s_%s *%s = make_oci_%s_%s (tree, ctx, err);
+    oci_%s *%s = make_oci_%s (tree, ctx, err);
     yajl_tree_free (tree);
     return %s;
 }
-""" % (prefix, prefix, prefix, prefix, prefix, prefix, prefix, prefix, prefix))
+""" % (prefix, prefix, prefix, prefix, prefix, prefix))
 
     c_file.write("""\n
-oci_%s_%s *oci_%s_parse_data (const char *jsondata, struct libocispec_context *ctx, oci_parser_error *err) {
+oci_%s *oci_%s_parse_data (const char *jsondata, struct libocispec_context *ctx, oci_parser_error *err) {
     yajl_val tree;
     *err = NULL;
     struct libocispec_context tmp_ctx;
@@ -664,11 +666,11 @@ oci_%s_%s *oci_%s_parse_data (const char *jsondata, struct libocispec_context *c
         return NULL;
     }
 
-    oci_%s_%s *%s = make_oci_%s_%s (tree, ctx, err);
+    oci_%s *%s = make_oci_%s (tree, ctx, err);
     yajl_tree_free (tree);
     return %s;
 }
-""" % (prefix, prefix, prefix, prefix, prefix, prefix, prefix, prefix, prefix))
+""" % (prefix, prefix, prefix, prefix, prefix, prefix))
 
 def generate(schema_json, header_name, header_file, c_file, prefix):
     tree = scan_main(schema_json, prefix)

--- a/src/validate.c
+++ b/src/validate.c
@@ -27,7 +27,7 @@ int
 main (int argc, char *argv[])
 {
   oci_parser_error err;
-  oci_container_container *container;
+  oci_container *container;
   const char *file = "config.json";
   struct libocispec_context ctx;
 
@@ -39,7 +39,7 @@ main (int argc, char *argv[])
 
   container = oci_container_parse_file (file, &ctx, &err);
   if (container)
-    free_oci_container_container (container);
+    free_oci_container (container);
 
   if (err)
     error (EXIT_FAILURE, 0, "error in %s: %s", file, err);

--- a/tests/test-1.c
+++ b/tests/test-1.c
@@ -26,7 +26,7 @@ int
 main (int argc, char *argv[])
 {
   oci_parser_error err;
-  oci_container_container *container = oci_container_parse_file ("tests/config.json", 0, &err);
+  oci_container *container = oci_container_parse_file ("tests/config.json", 0, &err);
 
   if (container == NULL) {
     printf ("error %s\n", err);
@@ -62,6 +62,6 @@ main (int argc, char *argv[])
     exit (5);
   if (container->linux->resources->blockIO->throttleWriteIopsDevice[0]->rate != 300)
     exit (5);
-  free_oci_container_container (container);
+  free_oci_container (container);
   exit (0);
 }

--- a/tests/test-2.c
+++ b/tests/test-2.c
@@ -26,7 +26,7 @@ int
 main (int argc, char *argv[])
 {
   oci_parser_error err;
-  oci_container_container *container = oci_container_parse_file ("tests/config.nocwd.json", 0, &err);
+  oci_container *container = oci_container_parse_file ("tests/config.nocwd.json", 0, &err);
   if (container != NULL) {
     exit (4);
   }

--- a/tests/test-3.c
+++ b/tests/test-3.c
@@ -26,7 +26,7 @@ int
 main (int argc, char *argv[])
 {
   oci_parser_error err;
-  oci_image_image *image = oci_image_parse_file ("tests/image_config.json", 0, &err);
+  oci_image *image = oci_image_parse_file ("tests/image_config.json", 0, &err);
 
   if (image == NULL) {
     printf ("error %s\n", err);
@@ -52,6 +52,6 @@ main (int argc, char *argv[])
     exit (5);
   if (strcmp (image->config->Volumes[1], "/var/log/my-app-logs"))
     exit (5);
-  free_oci_image_image (image);
+  free_oci_image (image);
   exit (0);
 }

--- a/tests/test-4.c
+++ b/tests/test-4.c
@@ -26,7 +26,7 @@ int
 main (int argc, char *argv[])
 {
   oci_parser_error err;
-  oci_image_index_image_index *image_index = oci_image_index_parse_file ("tests/image_index_config.json", 0, &err);
+  oci_image_index *image_index = oci_image_index_parse_file ("tests/image_index_config.json", 0, &err);
 
   if (image_index == NULL) {
     printf ("error %s\n", err);
@@ -59,6 +59,6 @@ main (int argc, char *argv[])
   if (strcmp (image_index->manifests[0]->platform->architecture, "ppc64le"))
     exit (5);
 
-  free_oci_image_index_image_index (image_index);
+  free_oci_image_index (image_index);
   exit (0);
 }

--- a/tests/test-5.c
+++ b/tests/test-5.c
@@ -26,7 +26,7 @@ int
 main (int argc, char *argv[])
 {
   oci_parser_error err;
-  oci_image_layout_image_layout *image_layout = oci_image_layout_parse_file ("tests/image_layout_config.json", 0, &err);
+  oci_image_layout *image_layout = oci_image_layout_parse_file ("tests/image_layout_config.json", 0, &err);
 
   if (image_layout == NULL) {
     printf ("error %s\n", err);
@@ -35,6 +35,6 @@ main (int argc, char *argv[])
   if (strcmp (image_layout->imageLayoutVersion, "1.0.0"))
     exit (5);
 
-  free_oci_image_layout_image_layout (image_layout);
+  free_oci_image_layout (image_layout);
   exit (0);
 }

--- a/tests/test-6.c
+++ b/tests/test-6.c
@@ -26,7 +26,7 @@ int
 main (int argc, char *argv[])
 {
   oci_parser_error err;
-  oci_image_manifest_image_manifest *manifest = oci_image_manifest_parse_file ("tests/image_manifest.json", 0, &err);
+  oci_image_manifest *manifest = oci_image_manifest_parse_file ("tests/image_manifest.json", 0, &err);
 
   if (manifest == NULL) {
     printf ("error %s\n", err);
@@ -48,6 +48,6 @@ main (int argc, char *argv[])
     exit (5);
   if (strcmp(manifest->annotations->values[1], "value2"))
     exit (5);
-  free_oci_image_manifest_image_manifest (manifest);
+  free_oci_image_manifest (manifest);
   exit (0);
 }

--- a/tests/test-7.c
+++ b/tests/test-7.c
@@ -26,7 +26,7 @@ int
 main (int argc, char *argv[])
 {
   oci_parser_error err;
-  oci_image_image *image = oci_image_parse_file ("tests/image_config_mapstringobject.json", 0, &err);
+  oci_image *image = oci_image_parse_file ("tests/image_config_mapstringobject.json", 0, &err);
 
   if (image == NULL) {
     printf ("error %s\n", err);
@@ -40,6 +40,6 @@ main (int argc, char *argv[])
     exit (5);
   if (image->config->ExposedPorts != NULL)
     exit (5);
-  free_oci_image_image (image);
+  free_oci_image (image);
   exit (0);
 }


### PR DESCRIPTION
The current name of top struct has two repeated prefix,
such as oci_container_container, oci_image_manifest_image_manifest.

We'd better generate one prefix for the top struct, make it more
readable and simplified. Such as oci_container, oci_image_manifest

Signed-off-by: Yifeng Tan <tanyifeng1@huawei.com>