### PR TITLE
read-file.c: fix overwrite the last Byte of buf

### DIFF
--- a/src/read-file.c
+++ b/src/read-file.c
@@ -41,7 +41,7 @@ fread_file (FILE *stream, size_t *length)
       if (ret < BUFSIZ || feof (stream))
         {
           *length = off + ret;
-          buf[*length - 1] = '\0';
+          buf[*length] = '\0';
           return buf;
         }
       off += BUFSIZ;


### PR DESCRIPTION
'length' is the actually data size of buf, `buf[*length - 1] ` point to valid data, we should add '\0' after it to avoid overwrite the last Byte of buf.

Signed-off-by: Yifeng Tan <tanyifeng1@huawei.com>