### PR TITLE
generate.py: fix error when parse `anyOf`

### DIFF
--- a/src/generate.py
+++ b/src/generate.py
@@ -485,8 +485,9 @@ def resolve_type(name, src, cur):
             subtyp = children[0].typ
             subtypobj = children
         elif 'anyOf' in cur["items"]:
-            children = scan_list(name, src, cur["items"]['anyOf'])
-            subtyp = children[0].typ
+            anychildren = scan_list(name, src, cur["items"]['anyOf'])
+            subtyp = anychildren[0].typ
+            children = anychildren[0].children
             subtypobj = children
         elif '$ref' in cur["items"]:
             item_type, src = resolve_type(name, src, cur["items"])

--- a/tests/test-1.c
+++ b/tests/test-1.c
@@ -62,6 +62,10 @@ main (int argc, char *argv[])
     exit (5);
   if (container->linux->resources->block_io->throttle_write_iops_device[0]->rate != 300)
     exit (5);
+  if (container->linux->namespaces_len != 5)
+    exit (5);
+  if (strcmp(container->linux->namespaces[2]->type, "ipc"))
+    exit (5);
   free_oci_container (container);
   exit (0);
 }


### PR DESCRIPTION
we got some error when parse 'anyOf' in [runtime-spec/anyOf](https://github.com/opencontainers/runtime-spec/blob/30bdf3b2b39cefe7f13b1751d37d9d397c9cfceb/schema/config-linux.json#L32):

```
typedef struct {
    oci_container_namespace_reference *namespace_reference;
}
oci_container_linux_namespaces_element;
```

Because '$ref' is in cur["items"], and scan_list take it as children, this PR handle 'anyOf' like 'allOf', but not merge the results(equal to 'anychildren') of `scan_list`, and just take one of anychildren as actually children, for now, 'anyOf' only present once, so we take the 1st element as result.

```
typedef struct {
    char *path;
    char *type;
}
oci_container_linux_namespaces_element;
```

Signed-off-by: Yifeng Tan <tanyifeng1@huawei.com>