### PR TITLE
Parse any schema

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,8 +10,8 @@ src/oci_image_layout_spec.c
 src/oci_image_layout_spec.h
 src/oci_image_manifest_spec.c
 src/oci_image_manifest_spec.h
-src/oci_json_common.h
-src/oci_json_common.c
+src/json_common.h
+src/json_common.c
 Makefile
 Makefile.in
 aclocal.m4

--- a/Makefile.am
+++ b/Makefile.am
@@ -11,27 +11,27 @@ SOURCE_FILES = src/oci_runtime_spec.c \
 	src/oci_image_index_spec.c \
 	src/oci_image_layout_spec.c \
 	src/oci_image_manifest_spec.c \
-	src/oci_json_common.c
+	src/json_common.c
 
 HEADER_FILES = $(SOURCE_FILES:.c=.h)
 
-src/oci_json_common.h src/oci_json_common.c:
+src/json_common.h src/json_common.c:
 	$(srcdir)/src/generate.py
 
-src/oci_runtime_spec.c: runtime-spec/schema/config-schema.json src/generate.py src/oci_json_common.h
-	$(srcdir)/src/generate.py $(srcdir)/runtime-spec/schema/config-schema.json src/oci_runtime_spec.h src/oci_runtime_spec.c container
+src/oci_runtime_spec.c: runtime-spec/schema/config-schema.json src/generate.py src/json_common.h
+	$(srcdir)/src/generate.py $(srcdir)/runtime-spec/schema/config-schema.json src/oci_runtime_spec.h src/oci_runtime_spec.c oci_container
 
-src/oci_image_spec.c: image-spec/schema/config-schema.json src/generate.py src/oci_json_common.h
-	$(srcdir)/src/generate.py $(srcdir)/image-spec/schema/config-schema.json src/oci_image_spec.h src/oci_image_spec.c image
+src/oci_image_spec.c: image-spec/schema/config-schema.json src/generate.py src/json_common.h
+	$(srcdir)/src/generate.py $(srcdir)/image-spec/schema/config-schema.json src/oci_image_spec.h src/oci_image_spec.c oci_image
 
-src/oci_image_index_spec.c: image-spec/schema/image-index-schema.json src/generate.py src/oci_json_common.h
-	$(srcdir)/src/generate.py $(srcdir)/image-spec/schema/image-index-schema.json src/oci_image_index_spec.h src/oci_image_index_spec.c image_index
+src/oci_image_index_spec.c: image-spec/schema/image-index-schema.json src/generate.py src/json_common.h
+	$(srcdir)/src/generate.py $(srcdir)/image-spec/schema/image-index-schema.json src/oci_image_index_spec.h src/oci_image_index_spec.c oci_image_index
 
-src/oci_image_layout_spec.c: image-spec/schema/image-layout-schema.json src/generate.py src/oci_json_common.h
-	$(srcdir)/src/generate.py $(srcdir)/image-spec/schema/image-layout-schema.json src/oci_image_layout_spec.h src/oci_image_layout_spec.c image_layout
+src/oci_image_layout_spec.c: image-spec/schema/image-layout-schema.json src/generate.py src/json_common.h
+	$(srcdir)/src/generate.py $(srcdir)/image-spec/schema/image-layout-schema.json src/oci_image_layout_spec.h src/oci_image_layout_spec.c oci_image_layout
 
-src/oci_image_manifest_spec.c: image-spec/schema/image-manifest-schema.json src/generate.py src/oci_json_common.h
-	$(srcdir)/src/generate.py $(srcdir)/image-spec/schema/image-manifest-schema.json src/oci_image_manifest_spec.h src/oci_image_manifest_spec.c image_manifest
+src/oci_image_manifest_spec.c: image-spec/schema/image-manifest-schema.json src/generate.py src/json_common.h
+	$(srcdir)/src/generate.py $(srcdir)/image-spec/schema/image-manifest-schema.json src/oci_image_manifest_spec.h src/oci_image_manifest_spec.c oci_image_manifest
 
 $(HEADER_FILES): %.h: %.c src/generate.py
 
@@ -96,6 +96,6 @@ EXTRA_DIST = autogen.sh \
 	src/generate.py \
 	$(HEADER_FILES) \
 	src/read-file.h \
-	src/oci_json_common.h \
+	src/json_common.h \
 	runtime-spec \
 	image-spec

--- a/src/generate.py
+++ b/src/generate.py
@@ -766,13 +766,15 @@ oci_%s *oci_%s_parse_file (const char *filename, struct libocispec_context *ctx,
     char *content = read_file (filename, &filesize);
     char errbuf[1024];
     if (content == NULL) {
-        asprintf (err, "cannot read the file: %%s", filename);
+        if (asprintf (err, "cannot read the file: %%s", filename) < 0)
+            *err = "error allocating memory";
         return NULL;
     }
     tree = yajl_tree_parse (content, errbuf, sizeof(errbuf));
     free (content);
     if (tree == NULL) {
-        asprintf (err, "cannot parse the file: %%s", errbuf);
+        if (asprintf (err, "cannot parse the file: %%s", errbuf) < 0)
+            *err = "error allocating memory";
         return NULL;
     }
 

--- a/src/generate.py
+++ b/src/generate.py
@@ -19,51 +19,35 @@
 import os, sys, json
 
 '''
-This function transform "name" to "fixedname" which is conform to Linux Kernel Naming specification
-It has three steps, assume that we have name = "user_CPUCached"
-1. split "name" to an array by '_' and word that beginning with uppercase letter: ["user", "_", "C", "P", "U", "Cached"]
-2. binding single upper string "C" "P" and "U" to "CPU", we got new array: ["user", "_", "CPU", "Cached"]
-3. generate "fixedname" with above array one by one, all elements in the array are translated to lowercase,
-   and add '_' between adjacent elements only when fixedname[-1] != '_' and the following element not beginning with '_'
-Finally, fixedname = "user_cpu_cached"
+This function transform "name" to "fixedname" which is conform to Linux Kernel Naming specification.
+Spliting "name" by '_' and word that beginning with uppercase letter,
+bind continuously single uppercase to one word, translate all words to lowercase,
+and add '_' between adjacent words only when fixedname[-1] != '_' and the following word not beginning with '_'.
 '''
 def transform_to_C_name(name):
-    fixedname = ""
-    subname = []
-    tmpindex = 0
-    length = len(name)
-    i = 0
-    while i < length:
-        if (name[i].isupper() or name[i] == '_'):
-            # split index found
-            if tmpindex != i:
-                subname.append(name[tmpindex:i])
-                tmpindex = i
-            # binding whole word
-            if (name[i].isupper()):
-                while (i != (length - 1) and name[i + 1].islower()):
-                    i = i + 1
-            subname.append(name[tmpindex:(i + 1)])
-            tmpindex = i + 1
-        i = i + 1
-
-    # append trailing lower string
-    if tmpindex != length:
-        subname.append(name[tmpindex:length])
-
-    sublength = len(subname)
-    i = 0
-    while i < sublength:
-        if (len(subname[i]) == 1 and subname[i].isupper()):
-            # binding single upper string
-            while(i != (sublength - 1) and len(subname[i + 1]) == 1 and subname[i + 1].isupper()):
-                i = i + 1
-                subname[i] = subname[i-1] + subname[i]
-        if (len(fixedname) != 0 and fixedname[-1] != '_' and subname[i][0] != '_'):
-            fixedname += '_'
-        fixedname += subname[i].lower()
-        i = i + 1
-    return fixedname
+    parts = []
+    preindex = 0
+    for index, char in enumerate(name):
+        if char == '_':
+            if parts and parts[-1] is not '_':
+                parts.append('_')
+            parts.append(name[preindex:index].lower())
+            preindex = index + 1
+            parts.append('_')
+        elif not char.isupper() and name[preindex].isupper() and name[preindex+1].isupper():
+            if parts and parts[-1] is not '_':
+                parts.append('_')
+            parts.append(name[preindex:index-1].lower())
+            preindex = index - 1
+        elif char.isupper() and index > 0 and name[index-1].islower():
+            if parts and parts[-1] is not '_':
+                parts.append('_')
+            parts.append(name[preindex:index].lower())
+            preindex = index
+    if preindex <= index and index >= 0 and name[index] is not '_' and preindex != 0 and parts[-1] is not '_':
+        parts.append('_')
+    parts.append(name[preindex:index+1].lower())
+    return ''.join(parts)
 
 class Name:
     def __init__(self, name, leaf=None):

--- a/src/validate.c
+++ b/src/validate.c
@@ -26,15 +26,15 @@ along with libocispec.  If not, see <http://www.gnu.org/licenses/>.
 int
 main (int argc, char *argv[])
 {
-  oci_parser_error err;
+  parser_error err;
   oci_container *container;
   const char *file = "config.json";
-  struct libocispec_context ctx;
+  struct parser_context ctx;
 
   if (argc > 1)
     file = argv[1];
 
-  ctx.options = LIBOCISPEC_OPTIONS_STRICT;
+  ctx.options = PARSE_OPTIONS_STRICT;
   ctx.stderr = stderr;
 
   container = oci_container_parse_file (file, &ctx, &err);

--- a/tests/test-1.c
+++ b/tests/test-1.c
@@ -25,7 +25,7 @@ along with libocispec.  If not, see <http://www.gnu.org/licenses/>.
 int
 main (int argc, char *argv[])
 {
-  oci_parser_error err;
+  parser_error err;
   oci_container *container = oci_container_parse_file ("tests/data/config.json", 0, &err);
   oci_container *container_gen = NULL;
   char *json_buf = NULL;

--- a/tests/test-2.c
+++ b/tests/test-2.c
@@ -25,7 +25,7 @@ along with libocispec.  If not, see <http://www.gnu.org/licenses/>.
 int
 main (int argc, char *argv[])
 {
-  oci_parser_error err;
+  parser_error err;
   oci_container *container = oci_container_parse_file ("tests/data/config.nocwd.json", 0, &err);
   if (container != NULL) {
     exit (4);

--- a/tests/test-3.c
+++ b/tests/test-3.c
@@ -25,7 +25,7 @@ along with libocispec.  If not, see <http://www.gnu.org/licenses/>.
 int
 main (int argc, char *argv[])
 {
-  oci_parser_error err;
+  parser_error err;
   oci_image *image = oci_image_parse_file ("tests/data/image_config.json", 0, &err);
   oci_image *image_gen = NULL;
   char *json_buf = NULL;

--- a/tests/test-4.c
+++ b/tests/test-4.c
@@ -25,7 +25,7 @@ along with libocispec.  If not, see <http://www.gnu.org/licenses/>.
 int
 main (int argc, char *argv[])
 {
-  oci_parser_error err;
+  parser_error err;
   oci_image_index *image_index = oci_image_index_parse_file ("tests/data/image_index_config.json", 0, &err);
   oci_image_index *image_index_gen = NULL;
   char *json_buf = NULL;

--- a/tests/test-5.c
+++ b/tests/test-5.c
@@ -25,7 +25,7 @@ along with libocispec.  If not, see <http://www.gnu.org/licenses/>.
 int
 main (int argc, char *argv[])
 {
-  oci_parser_error err;
+  parser_error err;
   oci_image_layout *image_layout = oci_image_layout_parse_file ("tests/data/image_layout_config.json", 0, &err);
   oci_image_layout *image_layout_gen = NULL;
   char *json_buf = NULL;

--- a/tests/test-6.c
+++ b/tests/test-6.c
@@ -25,7 +25,7 @@ along with libocispec.  If not, see <http://www.gnu.org/licenses/>.
 int
 main (int argc, char *argv[])
 {
-  oci_parser_error err;
+  parser_error err;
   oci_image_manifest *manifest = oci_image_manifest_parse_file ("tests/data/image_manifest.json", 0, &err);
   oci_image_manifest *manifest_gen = NULL;
   char *json_buf = NULL;

--- a/tests/test-7.c
+++ b/tests/test-7.c
@@ -25,7 +25,7 @@ along with libocispec.  If not, see <http://www.gnu.org/licenses/>.
 int
 main (int argc, char *argv[])
 {
-  oci_parser_error err;
+  parser_error err;
   oci_image *image = oci_image_parse_file ("tests/data/image_config_mapstringobject.json", 0, &err);
   oci_image *image_gen = NULL;
   char *json_buf = NULL;


### PR DESCRIPTION
We are trying to make `generate.py` be a common script to parse any json-schema, because others have interest in using it, but have trouble with current prefix name `oci`, so we've done:

1. Reimplemented `transform_to_C_name`

2. Removed all prefix `oci` in generate.py, and transfer it by `prefix` in `Makefile.am`, then `generate.py` can be used to parse any json-schema with its own prefix, and this project still surpport `runtimespec` and `imagespec`