### PR TITLE
Fix err required

### DIFF
--- a/src/generate.py
+++ b/src/generate.py
@@ -242,7 +242,7 @@ def generate_C_parse(obj, c_file, prefix):
         for i in required_to_check:
             c_file.write('    if (ret->%s == NULL) {\n' % i.fixname)
             c_file.write('        if (asprintf (err, "Required field %%s not present", "%s") < 0) {\n' % i.origname)
-            c_file.write('            *err = "error allocating memory";\n')
+            c_file.write('            *err = strdup("error allocating memory");\n')
             c_file.write('            return NULL;\n')
             c_file.write("        }\n")
             c_file.write("        free_%s (ret);\n" % obj_typename)
@@ -751,14 +751,14 @@ def generate_C_epilogue(c_file, prefix):
     char errbuf[1024];
     if (content == NULL) {
         if (asprintf (err, "cannot read the file: %%s", filename) < 0)
-            *err = "error allocating memory";
+            *err = strdup("error allocating memory");
         return NULL;
     }
     tree = yajl_tree_parse (content, errbuf, sizeof(errbuf));
     free (content);
     if (tree == NULL) {
         if (asprintf (err, "cannot parse the file: %%s", errbuf) < 0)
-            *err = "error allocating memory";
+            *err = strdup("error allocating memory");
         return NULL;
     }
 
@@ -787,7 +787,8 @@ def generate_C_epilogue(c_file, prefix):
     tree = yajl_tree_parse (content, errbuf, sizeof(errbuf));
     free (content);
     if (tree == NULL) {
-        *err = strdup ("cannot parse the file");
+        if (asprintf (err, "cannot parse the stream: %%s", errbuf) < 0)
+            *err = strdup("error allocating memory");
         return NULL;
     }
 
@@ -813,7 +814,8 @@ def generate_C_epilogue(c_file, prefix):
     }
     tree = yajl_tree_parse (jsondata, errbuf, sizeof(errbuf));
     if (tree == NULL) {
-        *err = strdup ("cannot parse the json data");
+        if (asprintf (err, "cannot parse the data: %%s", errbuf) < 0)
+            *err = strdup("error allocating memory");
         return NULL;
     }
 

--- a/src/generate.py
+++ b/src/generate.py
@@ -164,7 +164,7 @@ def generate_C_parse(obj, c_file, prefix):
 
         required_to_check = []
         for i in (nodes or []):
-            if obj.required and i.origname in obj.required and not is_numeric_type(i.typ):
+            if obj.required and i.origname in obj.required and not is_numeric_type(i.typ) and i.typ != 'boolean':
                 required_to_check.append(i)
             if i.typ == 'string':
                 c_file.write('    {\n')
@@ -639,10 +639,10 @@ def resolve_type(name, src, cur):
             subtypobj = children
         elif '$ref' in cur["items"]:
             item_type, src = resolve_type(name, src, cur["items"])
-            return Node(name, typ, None, subtyp=item_type.typ, subtypobj=item_type.children), src
+            return Node(name, typ, None, subtyp=item_type.typ, subtypobj=item_type.children, required=item_type.required), src
         elif 'type' in cur["items"]:
             item_type, src = resolve_type(name, src, cur["items"])
-            return Node(name, typ, None, subtyp=item_type.typ, subtypobj=item_type.children), src
+            return Node(name, typ, None, subtyp=item_type.typ, subtypobj=item_type.children, required=item_type.required), src
     elif typ == 'object':
         if 'allOf' in cur:
             children = merge(scan_list(name, src, cur['allOf']))
@@ -686,7 +686,10 @@ def scan_properties(name, schema, props):
     return scan_dict(name, schema, props['properties'])
 
 def scan_main(schema, prefix):
-    return Node(Name(prefix), "object", scan_properties(Name(""), schema, schema))
+    required = None;
+    if 'required' in schema:
+        required = schema['required']
+    return Node(Name(prefix), "object", scan_properties(Name(""), schema, schema), None, None, required)
 
 def flatten(tree, structs, visited={}):
     if tree.children is not None:


### PR DESCRIPTION
1. Fix segment fault if call `free(err)` when `err` is not allocated by `malloc`.

2. Fix required filed check for all generated `Node`.