### PR TITLE
generate.py: support parsing top type 'array'

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,6 +10,8 @@ src/oci_image_layout_spec.c
 src/oci_image_layout_spec.h
 src/oci_image_manifest_spec.c
 src/oci_image_manifest_spec.h
+src/image_manifest_items.c
+src/image_manifest_items.h
 src/oci_json_common.c
 src/oci_json_common.h
 src/json_common.h
@@ -50,6 +52,8 @@ tests/test-6.log
 tests/test-6.trs
 tests/test-7.log
 tests/test-7.trs
+tests/test-8.log
+tests/test-8.trs
 tests/test-1
 tests/test-2
 tests/test-3
@@ -57,3 +61,4 @@ tests/test-4
 tests/test-5
 tests/test-6
 tests/test-7
+tests/test-8

--- a/Makefile.am
+++ b/Makefile.am
@@ -11,6 +11,7 @@ SOURCE_FILES = src/oci_runtime_spec.c \
 	src/oci_image_index_spec.c \
 	src/oci_image_layout_spec.c \
 	src/oci_image_manifest_spec.c \
+	src/image_manifest_items.c \
 	src/json_common.c
 
 HEADER_FILES = $(SOURCE_FILES:.c=.h)
@@ -32,6 +33,9 @@ src/oci_image_layout_spec.c: image-spec/schema/image-layout-schema.json src/gene
 
 src/oci_image_manifest_spec.c: image-spec/schema/image-manifest-schema.json src/generate.py src/json_common.h
 	$(PYTHON) $(srcdir)/src/generate.py $(srcdir)/image-spec/schema/image-manifest-schema.json src/oci_image_manifest_spec.h src/oci_image_manifest_spec.c oci_image_manifest
+
+src/image_manifest_items.c: tests/test-spec/imageManifestItems/image-manifest-items-schema.json src/generate.py src/json_common.h
+	$(PYTHON) $(srcdir)/src/generate.py $(srcdir)/tests/test-spec/imageManifestItems/image-manifest-items-schema.json src/image_manifest_items.h src/image_manifest_items.c image_manifest_items
 
 $(HEADER_FILES): %.h: %.c src/generate.py
 
@@ -65,6 +69,9 @@ tests_test_6_LDADD = $(TESTS_LDADD)
 tests_test_7_SOURCES = tests/test-7.c
 tests_test_7_LDADD = $(TESTS_LDADD)
 
+tests_test_8_SOURCES = tests/test-8.c
+tests_test_8_LDADD = $(TESTS_LDADD)
+
 src_validate_SOURCES = src/validate.c
 src_validate_LDADD = $(TESTS_LDADD)
 
@@ -74,7 +81,8 @@ TESTS = tests/test-1 \
 	tests/test-4 \
 	tests/test-5 \
 	tests/test-6 \
-	tests/test-7
+	tests/test-7 \
+	tests/test-8
 
 noinst_PROGRAMS = src/validate $(TESTS)
 
@@ -93,6 +101,8 @@ EXTRA_DIST = autogen.sh \
 	tests/data/image_manifest.json \
 	tests/data/image_config.json \
 	tests/data/config.nocwd.json \
+	tests/data/image_manifest_item.json \
+	tests/test-spec \
 	src/generate.py \
 	$(HEADER_FILES) \
 	src/read-file.h \

--- a/src/read-file.c
+++ b/src/read-file.c
@@ -19,6 +19,8 @@
 #include "read-file.h"
 
 #include <stdlib.h>
+#include <string.h>
+#include <limits.h>
 
 char *
 fread_file (FILE *stream, size_t *length)
@@ -53,12 +55,22 @@ fread_file (FILE *stream, size_t *length)
 
 char *read_file (const char *path, size_t *length)
 {
-  char *buf = NULL;
-  FILE *f = fopen (path, "r");
-  if (f == NULL)
-    return NULL;
+    char *buf = NULL;
+    char *rpath = NULL;
 
-  buf = fread_file (f, length);
-  fclose (f);
-  return buf;
+    if (!path || !length || strlen (path) > PATH_MAX)
+        return NULL;
+
+    rpath = realpath (path, NULL);
+    if (rpath == NULL)
+        return NULL;
+
+    FILE *f = fopen (rpath, "r");
+    free(rpath);
+    if (f == NULL)
+        return NULL;
+
+    buf = fread_file (f, length);
+    fclose (f);
+    return buf;
 }

--- a/tests/data/image_manifest_item.json
+++ b/tests/data/image_manifest_item.json
@@ -1,0 +1,13 @@
+[
+	{
+		"Config":"5b117edd0b767986092e9f721ba2364951b0a271f53f1f41aff9dd1861c2d4fe.json",
+		"RepoTags":null,
+		"Layers":[
+			"e20c5c3444dd86d3e7ce9ddbc1e0cdc0ed02c08ea110612490578d05c153f1aa/layer.tar",
+			"450bfc2e8e428446718353669503dc0d4337508d0704a28c0a06973cdf90f18b/layer.tar",
+			"e5ffeddba503ff2220cf4587030131c2cee5aef6083df1d2559e3d576bf04c99/layer.tar",
+			"6de415c70d8eb466e8c4db907c7c151882632fd851f38ae90a89226c3ecf21f6/layer.tar",
+			"080c8e26809e5a3b25826ba37fff877cdd76d900857018e4b28bb0f19ab83325/layer.tar"
+		]
+	}
+]

--- a/tests/test-8.c
+++ b/tests/test-8.c
@@ -1,0 +1,66 @@
+/* Copyright (C) 2017 YiFeng Tan <tanyifeng1@huawei.com>
+
+libocispec is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 3 of the License, or
+(at your option) any later version.
+
+libocispec is distributed in the hope that it will be useful,
+but WITHOUT ANY WARRANTY; without even the implied warranty of
+MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+GNU General Public License for more details.
+
+You should have received a copy of the GNU General Public License
+along with libocispec.  If not, see <http://www.gnu.org/licenses/>.
+
+*/
+
+#include "config.h"
+#include <unistd.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <image_manifest_items.h>
+
+int
+main (int argc, char *argv[])
+{
+  parser_error err = NULL;
+  size_t len, len_gen;
+  image_manifest_items_element **image_items = image_manifest_items_parse_file ("tests/data/image_manifest_item.json", 0, &err, &len);
+  image_manifest_items_element **image_items_gen = NULL;
+  char *json_buf = NULL;
+
+  if (image_items == NULL) {
+    printf ("error %s\n", err);
+    exit (1);
+  }
+  json_buf = image_manifest_items_generate_json (image_items, len, 0, &err);
+  if (json_buf == NULL) {
+    printf ("gen error %s\n", err);
+    exit (1);
+  }
+
+  image_items_gen = image_manifest_items_parse_data (json_buf, 0, &err, &len_gen);
+  if (image_items_gen == NULL) {
+    printf ("parse error %s\n", err);
+    exit (1);
+  }
+
+  if (len != 1 || len != len_gen)
+    exit (5);
+  if (!image_items[0]->config || strcmp (image_items[0]->config, image_items_gen[0]->config) || \
+      strcmp (image_items_gen[0]->config, "5b117edd0b767986092e9f721ba2364951b0a271f53f1f41aff9dd1861c2d4fe.json"))
+    exit (6);
+  if (image_items[0]->layers_len != 5 || image_items[0]->layers_len != image_items_gen[0]->layers_len || \
+      strcmp (image_items[0]->layers[2], image_items_gen[0]->layers[2]) || \
+      strcmp (image_items_gen[0]->layers[2], "e5ffeddba503ff2220cf4587030131c2cee5aef6083df1d2559e3d576bf04c99/layer.tar"))
+    exit (7);
+  if (image_items[0]->repo_tags_len != 0 || image_items[0]->repo_tags_len != image_items_gen[0]->repo_tags_len || image_items[0]->repo_tags != NULL)
+    exit (8);
+
+  free (json_buf);
+  free_image_manifest_items (image_items, len);
+  free_image_manifest_items (image_items_gen, len_gen);
+  exit (0);
+}

--- a/tests/test-spec/imageManifestItems/image-manifest-items-schema.json
+++ b/tests/test-spec/imageManifestItems/image-manifest-items-schema.json
@@ -1,0 +1,40 @@
+{
+	"$schema": "http://json-schema.org/draft-04/schema#",
+	"title": "manifest item set",
+	"type": "array",
+	"items": {
+		"title": "manifest item",
+		"type": "object",
+		"description": "manifest item for image save and load",
+		"properties": {
+			"Config": {
+				"description": "",
+				"id": "",
+				"type": "string"
+			},
+			"Layers": {
+				"type": "array",
+				"minItems": 1,
+				"items": {
+					"type": "string"
+				}
+			},
+			"RepoTags": {
+				"type": "array",
+				"minItems": 1,
+				"items": {
+					"type": "string"
+				}
+			},
+			"Parent": {
+				"description": "",
+				"id": "",
+				"type": "string"
+			}
+		},
+		"required": [
+			"Config",
+			"Layers"
+		]
+	}
+}


### PR DESCRIPTION
Close #43 

1. optimizing some code for secure issue.

2. supporting top type 'array', for this type, generating new common interface, you can see the difference in `src/image_manifest_items.c | .h` after make:
```
xxx_element **xxx_parse_file (const char *filename, struct parser_context *ctx, parser_error *err, size_t *len);

xxx_element **xxx_parse_file_stream (FILE *stream, struct parser_context *ctx, parser_error *err, size_t *len);

xxx_element **xxx_parse_data (const char *jsondata, struct parser_context *ctx, parser_error *err, size_t *len);

char *xxx_generate_json (xxx_element **ptr, size_t len, struct parser_context *ctx, parser_error *err);
```

For now, There are two limitations.

1. I don't have a better way to automatically generate `free_xxx functions`, `make_xxx functions` and `gen_xxx functions` for array of `xxx`, So this is implemented by hard code in `generate.py`.

2. If top type is array, and items of this array is not object, such as string, `generate.py` will not work.

I'll fix these problems if I have time, and glad to see other PR to fix these issue.

Signed-off-by: Yifeng Tan <tanyifeng1@huawei.com>
  
  